### PR TITLE
🧱 ec2の80番をあけ、22ばんも全てのipに開けた

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -93,7 +93,15 @@ resource "aws_security_group" "receipt_scanner_sg" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = [local.allowed_cidr]
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow HTTP traffic"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   # アウトバウンドルール


### PR DESCRIPTION
## 概要
nginxを使用しているため、EC2の入口として、　80ばんが必要だった。
そのため、80番を開けている

また、現在の設定では、terraform applyした場所からしかec2にアクセスできない設定だったため、どこからでもアクセスできるようにした。keyがあるため、　大丈夫と見込んでいる

## 動作確認
<img width="1314" alt="スクリーンショット 2024-12-01 7 44 05" src="https://github.com/user-attachments/assets/eb2106b4-a6bb-4a3c-9852-7ae0e014777b">
